### PR TITLE
Fix-Toast-Overlapping #20

### DIFF
--- a/app/src/main/res/layout/activity_clinometer.xml
+++ b/app/src/main/res/layout/activity_clinometer.xml
@@ -192,7 +192,7 @@
             android:layout_height="wrap_content"
             android:background="@drawable/rounded_corner"
             android:padding="10dp"
-            android:layout_marginBottom="50dp"
+            android:layout_marginBottom="100dp"
             android:layout_marginLeft="20dp"
             android:layout_marginRight="20dp"
             android:textColor="@color/line_white"


### PR DESCRIPTION
Fixed the overlapping of two toast messaages i.e :- 
1. Keep phone screen vertical
2. Press back again to exit.